### PR TITLE
Corrected license classifer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description='Python client for Intel471',
     packages=['pyintel471'],
     classifiers=[
-        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+        'License :: OSI Approved :: BSD License',
         'Development Status :: 3 - Alpha',
         'Environment :: Console',
         'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
LICENSE file states BSD-licensed code, but setup.py contained a value for `classifier` that would have people find the package in PyPi under AGPLv3+. (The two license types are incompatible. It's presumed that the author intended BSD license, but sending in a PR to verify.)